### PR TITLE
Make it easier to find the output channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.5] - 2022-07-25
+
+- When the ownership status bar item indicates an error, clicking on the status bar item will show the extension's Output Channel.
+
 ## [0.0.4] - 2022-05-13
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ View code ownership information within your favorite editor!
 
 ## Features
 
-View code ownership for every file right in the status bar. You'll the the name of the owning team in the status bar or an alert showing that the file is unowned.
+View code ownership for every file right in the status bar. You'll get the name of the owning team in the status bar or an alert showing that the file is unowned.
 
-Quick access to the owning teams config file. Clicking on the status bar item will open a popup that includes a button that opens the team's config file. See [Code Teams](https://github.com/rubyatscale/code_teams) for more information on team config files.
+Quick access to the owning team's config file. Clicking on the status bar item will open a popup that includes a button that opens the team's config file. See [Code Teams](https://github.com/rubyatscale/code_teams) for more information on team config files.
 
 ## Requirements
 
-This extension runs the [CodeOwnership](https://github.com/rubyatscale/code_ownership) CLI. You'll need to install and configure [CodeOwnership](https://github.com/rubyatscale/code_ownership) in your repository before using this extension. (Before it's setup, you'll see `Owner: error!` in the status bar.)
+This extension runs the [CodeOwnership](https://github.com/rubyatscale/code_ownership) CLI. You'll need to install and configure [CodeOwnership](https://github.com/rubyatscale/code_ownership) in your repository before using this extension. (Before it's set up, you'll see `Owner: error!` in the status bar.)
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This extension runs the [CodeOwnership](https://github.com/rubyatscale/code_owne
 
 ## Release Notes
 
+## 0.0.4 - 2022-07-25
+
+- When the ownership status bar item indicates an error, clicking on the status bar item will show the extension's Output Channel.
+
 ### 0.0.4 - 2022-05-13
 
 - Initial release

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,15 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('code-ownership-vscode.run', run),
   );
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'code-ownership-vscode.showOutputChannel',
+      () => {
+        channel.show();
+      },
+    ),
+  );
+
   const statusProvider = new StatusProvider(statusBarItem);
   context.subscriptions.push(statusProvider);
 
@@ -209,6 +218,12 @@ class StatusProvider implements vscode.Disposable {
   }
 
   private update() {
+    if (this.status === 'error') {
+      this.statusBarItem.command = 'code-ownership-vscode.showOutputChannel';
+    } else {
+      this.statusBarItem.command = 'code-ownership-vscode.showOwnershipInfo';
+    }
+
     if (this.status === 'error') {
       this.statusBarItem.text = '$(error) Owner: Error!';
       this.statusBarItem.tooltip = `See "${channel.name}" output channel for details`;


### PR DESCRIPTION
### Context
Previously, when the extension encountered an error, the error was logged via the output channel and the status bar item indicated an error state. Most users of VSCode, however, are not familiar with output channels and therefore it is not reasonable to expect them to look there when this extension shows an error state.

### Change
This change allows the user to click on the status bar item when its in an error state and be immediately taken to the extensions Output Channel. (When _not_ in an error state, the existing behavior persists: showing the info notification when the status bar item is clicked.)

### Expected Impact
This will reduce the friction for VSCode users to be able to see the [CodeOwnership](https://github.com/rubyatscale/code_ownership) CLI output. In doing so, it will reduce the friction of debugging [CodeOwnership](https://github.com/rubyatscale/code_ownership) when an error state is indicated by the extension.