### PR TITLE
Handle cases when a project doesn't use codeownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ View code ownership for every file right in the status bar. You'll get the name 
 Quick access to the owning team's config file. Clicking on the status bar item will open a popup that includes a button that opens the team's config file. See [Code Teams](https://github.com/rubyatscale/code_teams) for more information on team config files.
 
 ## Installation
+
 [Install from Marketplace](https://marketplace.visualstudio.com/items?itemName=Gusto.code-ownership-vscode)
 
 ## Requirements

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,6 +202,7 @@ class StatusProvider implements vscode.Disposable {
 
   private _status: Status = 'idle';
   private _owner: Owner | undefined = undefined;
+  private _isConfigured: boolean | null = null;
 
   get status(): Status {
     return this._status;
@@ -216,6 +217,14 @@ class StatusProvider implements vscode.Disposable {
   }
   set owner(value: Owner | undefined) {
     this._owner = value;
+    this.update();
+  }
+
+  get isConfigured(): boolean | null {
+    return this._isConfigured;
+  }
+  set isConfigured(value: boolean | null) {
+    this._isConfigured = value;
     this.update();
   }
 
@@ -239,9 +248,13 @@ class StatusProvider implements vscode.Disposable {
         this.statusBarItem.text = `$(account) Owner: ${this.owner.teamName}`;
         this.statusBarItem.tooltip = undefined;
         this.statusBarItem.show();
+      } else if (this.isConfigured === false) {
+        this.statusBarItem.text = `$(info) Ownership: not configured`;
+        this.statusBarItem.tooltip = 'This workspace is not configured for code ownership';
+        this.statusBarItem.show();
       } else {
         this.statusBarItem.text = `$(warning) Owner: none`;
-        this.statusBarItem.tooltip = undefined;
+        this.statusBarItem.tooltip = 'This file has no assigned team ownership';
         this.statusBarItem.show();
       }
     }
@@ -265,6 +278,7 @@ class Worker implements vscode.Disposable {
   private async checkConfiguration(): Promise<void> {
     const binaryPath = resolve(this.workspace.uri.fsPath, 'bin/codeownership');
     this.isConfigured = existsSync(binaryPath);
+    this.statusProvider.isConfigured = this.isConfigured;
 
     if (!this.isConfigured) {
       log('info', `No code ownership binary found in workspace: ${this.workspace.name}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,8 @@ let channel: vscode.OutputChannel;
 
 function run(file: string | vscode.Uri | null | undefined) {
   if (!file) {
-    run(vscode.window.activeTextEditor?.document.uri);
+    if (!vscode.window.activeTextEditor) return;
+    run(vscode.window.activeTextEditor.document.uri);
     return;
   }
 
@@ -254,7 +255,7 @@ class Worker implements vscode.Disposable {
   constructor(
     private readonly workspace: vscode.WorkspaceFolder,
     private readonly statusProvider: StatusProvider,
-  ) {}
+  ) { }
 
   workspaceHas(file: vscode.Uri): boolean {
     return file.fsPath.startsWith(this.workspace.uri.fsPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,7 +250,8 @@ class StatusProvider implements vscode.Disposable {
         this.statusBarItem.show();
       } else if (this.isConfigured === false) {
         this.statusBarItem.text = `$(info) Ownership: not configured`;
-        this.statusBarItem.tooltip = 'This workspace is not configured for code ownership';
+        this.statusBarItem.tooltip =
+          'This workspace is not configured for code ownership';
         this.statusBarItem.show();
       } else {
         this.statusBarItem.text = `$(warning) Owner: none`;
@@ -281,9 +282,15 @@ class Worker implements vscode.Disposable {
     this.statusProvider.isConfigured = this.isConfigured;
 
     if (!this.isConfigured) {
-      log('info', `No code ownership binary found in workspace: ${this.workspace.name}`);
+      log(
+        'info',
+        `No code ownership binary found in workspace: ${this.workspace.name}`,
+      );
     } else {
-      log('info', `Code ownership binary found in workspace: ${this.workspace.name}`);
+      log(
+        'info',
+        `Code ownership binary found in workspace: ${this.workspace.name}`,
+      );
     }
   }
 


### PR DESCRIPTION
I work on lots of codebases aside from ones with [code_ownership](https://github.com/rubyatscale/code_ownership), and I find it a little annoying to see "Owner: error!" when it isn't expected to work at all.

This adds a concept of checking that a workspace is configured for codeowners, or not. When it's not configured, it shows that with an info icon:

![CleanShot 2024-11-26 at 12 12 51](https://github.com/user-attachments/assets/d91bb58e-2ea4-4365-b063-70c9c3de0ed6)

Unrelated, but I fixed an error I was getting while using the debugging, which fixes an infinite recursion. I assume it is either debug/dev specific, or we'd see it more.