### PR TITLE
Version 0.2.0 to support codeowners-rs implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-10-14
+
+- Allow the command and file argument to be configured, so that it can work with the [Codeowners](https://github.com/rubyatscale/codeowners-rs) Rust-based implementation.
 ## [0.0.7] - 2022-07-25
 
 - When the ownership status bar item indicates an error, clicking on the status bar item will show the extension's Output Channel.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick access to the owning team's config file. Clicking on the status bar item w
 
 ## Requirements
 
-This extension runs the [CodeOwnership](https://github.com/rubyatscale/code_ownership) CLI. You'll need to install and configure [CodeOwnership](https://github.com/rubyatscale/code_ownership) in your repository before using this extension. (Before it's set up, you'll see `Owner: error!` in the status bar.)
+This extension runs the [CodeOwnership](https://github.com/rubyatscale/code_ownership) CLI. You'll need to install and configure either [CodeOwnership](https://github.com/rubyatscale/code_ownership) (Ruby) or [Codeowners](https://github.com/rubyatscale/codeowners-rs) (Rust) in your repository before using this extension. (Before it's set up, you'll see `Owner: error!` in the status bar.)
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-ownership-vscode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "Gusto",
   "displayName": "Code Ownership for VSCode",
   "description": "VSCode extension Big Rails Code Ownership",
@@ -17,6 +17,21 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/rubyatscale/code-ownership-vscode.git"
+  },
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "code-ownership-vscode.command": {
+        "type": "string",
+        "default": "bin/codeownership",
+        "description": "The executable command to run the code ownership tool."
+      },
+      "code-ownership-vscode.fileArg": {
+        "type": "string",
+        "default": "for_file",
+        "description": "The file argument to pass to the code ownership tool."
+      }
+    }
   },
   "contributes": {
     "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -277,7 +277,9 @@ class Worker implements vscode.Disposable {
   }
 
   private async checkConfiguration(): Promise<void> {
-    const binaryPath = resolve(this.workspace.uri.fsPath, 'bin/codeownership');
+    const config = vscode.workspace.getConfiguration('code-ownership-vscode');
+    const command = config.get<string>('command', 'bin/codeownership');
+    const binaryPath = resolve(this.workspace.uri.fsPath, command);
     this.isConfigured = existsSync(binaryPath);
     this.statusProvider.isConfigured = this.isConfigured;
 
@@ -322,11 +324,15 @@ class Worker implements vscode.Disposable {
     log('debug', `cwd: ${cwd}`);
     log('debug', `workspace: ${this.workspace.uri.fsPath}`);
     log('debug', `file path: ${file.fsPath}`);
+    
+    const config = vscode.workspace.getConfiguration('code-ownership-vscode');
+    const command = config.get<string>('command', 'bin/codeownership');
+    const fileArg = config.get<string>('fileArg', 'for_file');
 
     // Run ownership check
     const output = await runCommand(
       cwd,
-      `bin/codeownership for_file "${relativePath}" --json`,
+      `${command} ${fileArg} "${relativePath}" --json`,
       this.statusProvider,
     );
 


### PR DESCRIPTION
Allows configuration of the command and file argument so that it can work with the [Rust-based implementation of codeowners](https://github.com/rubyatscale/codeowners-rs) which has a different file argument (`for-file` vs `for_file`) and possibly located at a different location

This includes a minor bump of the version.
