### PR TITLE
Add advanced CodeQL setup to replace broken default setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '30 1 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.37.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- The Gusto enterprise-level security config (`Gusto Default Advanced Security`, enforced) disables code scanning **default (automatic) setup** org/enterprise-wide.
- That has left this repo's default CodeQL setup stuck erroring since the policy took effect, matching the pattern found and fixed in [rubyatscale/query_packwerk#37](https://github.com/rubyatscale/query_packwerk/pull/37).
- Adds `.github/workflows/codeql.yml`, an explicit **advanced setup** workflow. Pushing an advanced CodeQL workflow causes GitHub to automatically supersede the broken default-setup state, since advanced setup isn't subject to the same enterprise policy.

## Test plan
- [ ] Merge and confirm the `CodeQL` workflow runs successfully on `main`
- [ ] Confirm the code scanning status page no longer reports configuration errors
